### PR TITLE
Add dark mode toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,13 @@
 import Login from "./components/pages/login/Login";
 import { LogInProvider } from "./hooks/LogInContext";
+import ThemeToggle from "./components/ThemeToggle";
 
 const App: React.FC = () => {
   return (
     <LogInProvider>
+      <div className="absolute top-4 right-4">
+        <ThemeToggle />
+      </div>
       <Login />
     </LogInProvider>
   );

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+import { Switch } from "./ui/switch";
+
+const ThemeToggle = () => {
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("theme");
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const isDark = stored === "dark" || (!stored && prefersDark);
+    setEnabled(isDark);
+    if (isDark) {
+      document.documentElement.classList.add("dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+    }
+  }, []);
+
+  const toggle = () => {
+    const newTheme = enabled ? "light" : "dark";
+    setEnabled(!enabled);
+    if (newTheme === "dark") {
+      document.documentElement.classList.add("dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+    }
+    localStorage.setItem("theme", newTheme);
+  };
+
+  return (
+    <div className="flex items-center space-x-2">
+      <span className="text-sm">Dark Mode</span>
+      <Switch checked={enabled} onCheckedChange={toggle} />
+    </div>
+  );
+};
+
+export default ThemeToggle;


### PR DESCRIPTION
## Summary
- introduce a `ThemeToggle` component
- show the toggle in the app so users can enable dark mode

## Testing
- `npm run lint` *(fails: cannot find some packages)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842d14b030c832cae63f1635ef8c870